### PR TITLE
feat: Implement RequestBuilder and output printing

### DIFF
--- a/src/application/builders/mod.rs
+++ b/src/application/builders/mod.rs
@@ -1,0 +1,1 @@
+pub mod request_builder;

--- a/src/application/builders/request_builder.rs
+++ b/src/application/builders/request_builder.rs
@@ -1,0 +1,64 @@
+use crate::domain::entities::{Method, Request};
+use crate::domain::value_objects::{JsonBody, Url};
+use anyhow::{Result, anyhow};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+pub struct RequestBuilder {
+    method: Option<Method>,
+    url: Option<Url>,
+    headers: HashMap<String, String>,
+    body: Option<JsonBody>,
+}
+
+impl RequestBuilder {
+    pub fn new() -> Self {
+        Self {
+            method: None,
+            url: None,
+            headers: HashMap::new(),
+            body: None,
+        }
+    }
+
+    pub fn method(mut self, method: &str) -> Result<Self> {
+        self.method = Some(Method::from_str(method)?);
+        Ok(self)
+    }
+
+    pub fn url(mut self, raw_url: &str) -> Result<Self> {
+        self.url = Some(Url::new(raw_url)?);
+        Ok(self)
+    }
+
+    pub fn headers(mut self, raw_headers: &[String]) -> Result<Self> {
+        for raw in raw_headers {
+            let parts: Vec<&str> = raw.splitn(2, ':').collect();
+            if parts.len() != 2 {
+                return Err(anyhow!(
+                    "Invalid header format: '{}'. Use 'Key: Value'",
+                    raw
+                ));
+            }
+            self.headers
+                .insert(parts[0].trim().to_string(), parts[1].trim().to_string());
+        }
+        Ok(self)
+    }
+
+    pub fn body(mut self, json: &Option<String>) -> Result<Self> {
+        if let Some(data) = json {
+            self.body = Some(JsonBody::new(data)?);
+        }
+        Ok(self)
+    }
+
+    pub fn build(self) -> Request {
+        Request {
+            method: self.method.expect("Method is required"),
+            url: self.url.expect("URL is required"),
+            headers: self.headers.into_iter().collect(),
+            body: self.body,
+        }
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,1 +1,2 @@
+pub mod builders;
 pub mod services;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,1 +1,2 @@
 pub mod http_client;
+pub mod output;

--- a/src/infrastructure/output.rs
+++ b/src/infrastructure/output.rs
@@ -1,0 +1,15 @@
+use anyhow::{Result, anyhow};
+use colored::Colorize;
+use serde_json::Value;
+
+pub fn print_response_body(body: &str) -> Result<()> {
+    match serde_json::from_str::<Value>(body) {
+        Ok(json) => {
+            let pretty = serde_json::to_string_pretty(&json)
+                .map_err(|e| anyhow!("Failed to format JSON: {}", e))?;
+            println!("{}", pretty.green());
+        }
+        Err(_) => println!("{}", body.white()),
+    }
+    Ok(())
+}

--- a/src/presentation/cli.rs
+++ b/src/presentation/cli.rs
@@ -1,12 +1,8 @@
+use crate::application::builders::request_builder::RequestBuilder;
 use crate::application::services::HttpRequestService;
-use crate::domain::entities::{Method, Request};
-use crate::domain::value_objects::{JsonBody, Url};
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use clap::Parser;
 use colored::Colorize;
-use serde_json::Value;
-use std::collections::HashMap;
-use std::str::FromStr;
 
 /// CLI configuration for Hurl
 #[derive(Parser, Debug)]
@@ -17,30 +13,23 @@ use std::str::FromStr;
 )]
 #[command(about = "Hurl: Rust-powered requests that hit hard", long_about = None)]
 pub struct Cli {
-    /// The URL to send the request to
     pub url: String,
 
-    /// HTTP method (GET, POST, PUT, DELETE, etc.)
     #[arg(short, long, default_value = "GET")]
     pub method: String,
 
-    /// Headers in the format "Key: Value"
     #[arg(short = 'H', long = "header")]
     pub headers: Vec<String>,
 
-    /// Request body (usually JSON)
     #[arg(short = 'd', long = "data")]
     pub body: Option<String>,
 
-    /// Enable verbose output
     #[arg(short, long)]
     pub verbose: bool,
 
-    /// Output response to a file
     #[arg(short, long)]
     pub output: Option<String>,
 
-    /// Launch an interactive wizard
     #[arg(long)]
     pub wizard: bool,
 }
@@ -52,21 +41,12 @@ impl Cli {
             return Ok(());
         }
 
-        let url = Url::new(&self.url)?;
-        let method = Method::from_str(&self.method)?;
-
-        let headers = parse_headers(&self.headers)?;
-        let body = match &self.body {
-            Some(json) => Some(JsonBody::new(json)?),
-            None => None,
-        };
-
-        let request = Request {
-            method,
-            url,
-            headers: headers.into_iter().collect(),
-            body,
-        };
+        let request = RequestBuilder::new()
+            .method(&self.method)?
+            .url(&self.url)?
+            .headers(&self.headers)?
+            .body(&self.body)?
+            .build();
 
         let response = request_service.send_request(request).await?;
 
@@ -74,43 +54,16 @@ impl Cli {
             println!("{}", format!("Status: {}", response.status).cyan());
         }
 
-        if let Some(path) = &self.output {
-            std::fs::write(path, &response.body)?;
-            if self.verbose {
-                println!("Saved response to {}", path);
+        match &self.output {
+            Some(path) => {
+                std::fs::write(path, &response.body)?;
+                if self.verbose {
+                    println!("Saved response to {}", path);
+                }
             }
-        } else {
-            print_body(&response.body)?;
+            None => crate::infrastructure::output::print_response_body(&response.body)?,
         }
 
         Ok(())
     }
-}
-
-fn parse_headers(raw_headers: &[String]) -> Result<HashMap<String, String>> {
-    let mut headers = HashMap::new();
-    for raw in raw_headers {
-        let parts: Vec<&str> = raw.splitn(2, ':').collect();
-        if parts.len() != 2 {
-            return Err(anyhow!(
-                "Invalid header format: '{}'. Use 'Key: Value'",
-                raw
-            ));
-        }
-        headers.insert(parts[0].trim().to_string(), parts[1].trim().to_string());
-    }
-    Ok(headers)
-}
-
-fn print_body(body: &str) -> Result<()> {
-    match serde_json::from_str::<Value>(body) {
-        Ok(json) => println!(
-            "{}",
-            serde_json::to_string_pretty(&json)
-                .map_err(|e| anyhow!("Failed to format JSON: {}", e))?
-                .green()
-        ),
-        Err(_) => println!("{}", body.white()),
-    }
-    Ok(())
 }


### PR DESCRIPTION
Add RequestBuilder for constructing HTTP requests with method, URL, headers, and body. Introduce output printing functionality for formatted response display. Update CLI to utilize RequestBuilder for cleaner request handling.